### PR TITLE
OE-10587 Payload processor docker container crashing when processing the dicom files that needs Tesseract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,8 @@ ENV WAIT_SLEEP_INTERVAL=2
 # Copy compiled files
 COPY --from=builder ${PROJROOT}/target/ ${PROJROOT}
 COPY --from=builder ${PROJROOT}/src/main/resources/routineLibrary/ /routineLibrary
-COPY --from=builder ${PROJROOT}/src/main/resources/tessdata/ /tessdata
+RUN mkdir -p /tessdata
+RUN curl -o /tessdata/eng.traineddata -LJO https://github.com/tesseract-ocr/tessdata/raw/master/eng.traineddata
 
 # Add the init script
 COPY .docker_build/init.sh /init.sh


### PR DESCRIPTION
Replaced the traineddata file with the one from the tesseract repo. 
Git is showing no file changed but I've tested the problematic dicom file after building the docker image on this branch and it worked fine.